### PR TITLE
Make SelectionRequest trigger the selection owner's event callback

### DIFF
--- a/xevent/eventloop.go
+++ b/xevent/eventloop.go
@@ -258,7 +258,7 @@ func processEventQueue(xu *xgbutil.XUtil, pingBefore, pingAfter chan struct{}) {
 		case xproto.SelectionRequestEvent:
 			e := SelectionRequestEvent{&event}
 			xu.TimeSet(e.Time)
-			runCallbacks(xu, e, SelectionRequest, e.Requestor)
+			runCallbacks(xu, e, SelectionRequest, e.Owner)
 		case xproto.SelectionNotifyEvent:
 			e := SelectionNotifyEvent{&event}
 			xu.TimeSet(e.Time)


### PR DESCRIPTION
I've been working on clipboard transfer for Tomo, and I ran into this mysterious issue where the window that owned the CLIPBOARD selection would not receive any SelectionRequest events - and other clients would not be able to request the CLIPBOARD selection contents.

The issue was xevent attempting to dispatch the SelectionRequest callback of the selection requestor, instead of the owner. I've changed e.Requestor to e.Owner and fixed the issue.