### PR TITLE
Fix screen capture on screens with 24 bit depth and 32 bpp

### DIFF
--- a/xgraphics/new.go
+++ b/xgraphics/new.go
@@ -247,9 +247,9 @@ func readDrawableData(X *xgbutil.XUtil, ximg *Image, did xproto.Drawable,
 				}
 			}
 		}
-	case 24, 32:
+	case 24:
 		switch format.BitsPerPixel {
-		case 24:
+		case 24, 32:
 			bytesPer := int(format.BitsPerPixel) / 8
 			var i int
 			ximg.For(func(x, y int) BGRA {
@@ -261,6 +261,13 @@ func readDrawableData(X *xgbutil.XUtil, ximg *Image, did xproto.Drawable,
 					A: 0xff,
 				}
 			})
+		default:
+			return fmt.Errorf("The image returned for pixmap id %d has "+
+				"an unsupported value for bits-per-pixel: %d",
+				did, format.BitsPerPixel)
+		}
+	case 32:
+		switch format.BitsPerPixel {
 		case 32:
 			bytesPer := int(format.BitsPerPixel) / 8
 			var i int

--- a/xgraphics/new.go
+++ b/xgraphics/new.go
@@ -262,9 +262,9 @@ func readDrawableData(X *xgbutil.XUtil, ximg *Image, did xproto.Drawable,
 				}
 			})
 		default:
-			return fmt.Errorf("The image returned for pixmap id %d has "+
-				"an unsupported value for bits-per-pixel: %d",
-				did, format.BitsPerPixel)
+			return fmt.Errorf("The image returned for pixmap id %d with "+
+				"depth %d has an unsupported value for bits-per-pixel: %d",
+				did, format.Depth, format.BitsPerPixel)
 		}
 	case 32:
 		switch format.BitsPerPixel {
@@ -281,9 +281,9 @@ func readDrawableData(X *xgbutil.XUtil, ximg *Image, did xproto.Drawable,
 				}
 			})
 		default:
-			return fmt.Errorf("The image returned for pixmap id %d has "+
-				"an unsupported value for bits-per-pixel: %d",
-				did, format.BitsPerPixel)
+			return fmt.Errorf("The image returned for pixmap id %d with "+
+				"depth %d has an unsupported value for bits-per-pixel: %d",
+				did, format.Depth, format.BitsPerPixel)
 		}
 
 	default:


### PR DESCRIPTION
Currently on 24 bit depth and 32 bpp screens (e.g. ubuntu 24.04 with intel integrated graphics) screen capture produces image with right dimensions but with solid gray color fill. This happens because `readDrawableData` reads all pixels as fully transparent with alpha=0.

https://github.com/BurntSushi/xgbutil/issues/36