### PR TITLE
Correct license name in the README

### DIFF
--- a/README
+++ b/README
@@ -58,4 +58,4 @@ xpybutil project URL: https://github.com/BurntSushi/xpybutil
 jezek's Fork
 ============
 Why I've forked the xgbutil repository from BurntSushi's github is discussed in [issue #2](https://github.com/jezek/xgb/issues/2).
-I've also changed the LICENSE to GNU GPL v3 to meet the requirements for pkg.go.dev
+I've also changed the LICENSE to 3-clause BSD to meet the requirements for pkg.go.dev


### PR DESCRIPTION
I noticed the LICENSE file and the name of it in README did not match