### PR TITLE
Fix issue with window pixmaps that have an empty alpha but a valid mask

### DIFF
--- a/xgraphics/new.go
+++ b/xgraphics/new.go
@@ -150,14 +150,12 @@ func NewIcccmIcon(X *xgbutil.XUtil, iconPixmap,
 			for y = r.Min.Y; y < r.Max.Y; y++ {
 				maskBgra = mximg.At(x, y).(BGRA)
 				bgra = pximg.At(x, y).(BGRA)
-				if maskBgra.A == 0 {
-					pximg.SetBGRA(x, y, BGRA{
-						B: bgra.B,
-						G: bgra.G,
-						R: bgra.R,
-						A: 0,
-					})
-				}
+				pximg.SetBGRA(x, y, BGRA{
+					B: bgra.B,
+					G: bgra.G,
+					R: bgra.R,
+					A: maskBgra.A,
+				})
 			}
 		}
 		return pximg, nil

--- a/xgraphics/new.go
+++ b/xgraphics/new.go
@@ -154,7 +154,7 @@ func NewIcccmIcon(X *xgbutil.XUtil, iconPixmap,
 					B: bgra.B,
 					G: bgra.G,
 					R: bgra.R,
-					A: maskBgra.A,
+					A: uint8((uint16(bgra.A) * uint16(maskBgra.A)) / 0xff),
 				})
 			}
 		}


### PR DESCRIPTION
Cherry picking a fix from the out dated fyne-io fork of xgbutil

Corrects an issue for some combination of alpha and mask